### PR TITLE
feat: enhance likes & comments with validation

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -28,7 +28,8 @@
         "passport-local": "^1.0.0",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
-        "uuid": "^9.0.0"
+        "uuid": "^9.0.0",
+        "zod": "^3.22.4"
       },
       "devDependencies": {
         "@nestjs/testing": "^10.0.0",
@@ -8527,6 +8528,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,7 +27,8 @@
     "passport-local": "^1.0.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",

--- a/backend/src/common/errors/validation.error.ts
+++ b/backend/src/common/errors/validation.error.ts
@@ -1,0 +1,7 @@
+import { BadRequestException } from '@nestjs/common';
+
+export class ValidationError extends BadRequestException {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/backend/src/common/filters/all-exceptions.filter.ts
+++ b/backend/src/common/filters/all-exceptions.filter.ts
@@ -1,5 +1,12 @@
-import { ExceptionFilter, Catch, ArgumentsHost, HttpException, HttpStatus } from '@nestjs/common';
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
 import { Request, Response } from 'express';
+import { ValidationError } from '../errors/validation.error';
 
 @Catch()
 export class AllExceptionsFilter implements ExceptionFilter {
@@ -11,7 +18,10 @@ export class AllExceptionsFilter implements ExceptionFilter {
     let status = HttpStatus.INTERNAL_SERVER_ERROR;
     let message: any = 'Internal server error';
 
-    if (exception instanceof HttpException) {
+    if (exception instanceof ValidationError) {
+      status = HttpStatus.BAD_REQUEST;
+      message = exception.message;
+    } else if (exception instanceof HttpException) {
       status = exception.getStatus();
       const res = exception.getResponse();
       message = typeof res === 'string' ? res : (res as any).message;

--- a/backend/src/common/pipes/zod-validation.pipe.ts
+++ b/backend/src/common/pipes/zod-validation.pipe.ts
@@ -1,0 +1,16 @@
+import { PipeTransform, Injectable } from '@nestjs/common';
+import { ZodSchema } from 'zod';
+import { ValidationError } from '../errors/validation.error';
+
+@Injectable()
+export class ZodValidationPipe implements PipeTransform {
+  constructor(private schema: ZodSchema) {}
+
+  transform(value: any) {
+    const result = this.schema.safeParse(value);
+    if (!result.success) {
+      throw new ValidationError(result.error.errors.map(e => e.message).join(', '));
+    }
+    return result.data;
+  }
+}

--- a/backend/src/posts/posts.service.spec.ts
+++ b/backend/src/posts/posts.service.spec.ts
@@ -1,0 +1,62 @@
+import { Test } from '@nestjs/testing';
+import { MongooseModule } from '@nestjs/mongoose';
+import { PostsService } from './posts.service';
+import { Post, PostSchema } from './schemas/post.schema';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+
+describe('PostsService', () => {
+  let service: PostsService;
+  let mongo: MongoMemoryServer;
+  let moduleRef: any;
+
+  beforeAll(async () => {
+    mongo = await MongoMemoryServer.create({ binary: { version: '5.0.5' } });
+    moduleRef = await Test.createTestingModule({
+      imports: [
+        MongooseModule.forRoot(mongo.getUri()),
+        MongooseModule.forFeature([{ name: Post.name, schema: PostSchema }]),
+      ],
+      providers: [PostsService],
+    }).compile();
+
+    service = moduleRef.get(PostsService);
+  });
+
+  afterAll(async () => {
+    if (moduleRef) await moduleRef.close();
+    if (mongo) await mongo.stop();
+  });
+
+  it('likes and unlikes a post without duplicates', async () => {
+    const post: any = await service.create('u1', 'hello');
+    await Promise.all([
+      service.likePost(post._id.toString(), 'u2'),
+      service.likePost(post._id.toString(), 'u2'),
+    ]);
+    let fetched = await service.findOne(post._id.toString());
+    expect(fetched.likes).toHaveLength(1);
+    await service.unlikePost(post._id.toString(), 'u2');
+    fetched = await service.findOne(post._id.toString());
+    expect(fetched.likes).toHaveLength(0);
+  });
+
+  it('adds comments and paginates/sorts them', async () => {
+    const post: any = await service.create('u1', 'with comments');
+    await service.addComment(post._id.toString(), 'u2', 'first');
+    await service.addComment(post._id.toString(), 'u3', 'second');
+    const { comments } = await service.getComments(
+      post._id.toString(),
+      1,
+      1,
+      'latest',
+    );
+    expect(comments[0].content).toBe('second');
+    const { comments: older } = await service.getComments(
+      post._id.toString(),
+      1,
+      2,
+      'oldest',
+    );
+    expect(older[0].content).toBe('first');
+  });
+});


### PR DESCRIPTION
## Summary
- add atomic like/unlike and comment pagination
- introduce Zod validation pipe with custom errors
- expand tests for likes, comments and API flow

## Testing
- `cd backend && npm test` *(fails: DownloadError: Download failed for url "https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-5.0.5.tgz")*


------
https://chatgpt.com/codex/tasks/task_e_6895d199623c832ebc14a58e31c71929