### PR TITLE
feat: prevent duplicate user registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ curl -X POST http://localhost:3000/users/<USER_ID>/follow \
 ## API Reference
 
 ### Auth
-- `POST /auth/register` – create account. Body: `{ email, password }`. Returns user without password.
+- `POST /auth/register` – create account. Body: `{ email, password }`. Returns user without password; fails with `409 Conflict` if the email already exists.
 - `POST /auth/login` – authenticate and receive `{ access_token }`.
 - `POST /auth/google` – placeholder endpoint.
 - `POST /auth/discord` – placeholder endpoint.

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { User } from '../common/interfaces/user.interface';
 import { v4 as uuid } from 'uuid';
 
@@ -7,6 +11,9 @@ export class UsersService {
   private users = new Map<string, User>();
 
   create(email: string, password: string): User {
+    if (this.users.has(email)) {
+      throw new ConflictException('Email already registered');
+    }
     const user: User = { id: uuid(), email, password, followers: [], following: [] };
     this.users.set(email, user);
     return user;


### PR DESCRIPTION
## Summary
- disallow registering the same email more than once by throwing a conflict error
- document duplicate-email behavior in auth endpoint reference

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895e2e4f498832e8473061e86811431