### PR TITLE
feat(frontend): add registration to auth form

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A prototype social platform where users can register, share posts with optional 
 - [ ] Test coverage (Jest/unit/integration) – ~40%
 
 ### 🎨 Frontend
-- [ ] Authentication forms & routing – ~50% (login implemented)
+- [ ] Authentication forms & routing – ~75% (login & register implemented)
 - [ ] Post feed & UI integration – ~70%
 - [ ] Like/comment functionality – ~40%
 - [ ] File uploads & previews – ~40%

--- a/frontend/src/components/AuthForm.jsx
+++ b/frontend/src/components/AuthForm.jsx
@@ -1,13 +1,15 @@
 import { useState } from 'react';
-import { login } from '../api';
+import { login, register } from '../api';
 
 export default function AuthForm({ onSuccess }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [mode, setMode] = useState('login');
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const res = await login(email, password);
+    const fn = mode === 'login' ? login : register;
+    const res = await fn(email, password);
     onSuccess?.(res);
   };
 
@@ -26,9 +28,18 @@ export default function AuthForm({ onSuccess }) {
         onChange={(e) => setPassword(e.target.value)}
         className="w-full border p-2"
       />
-      <button type="submit" className="bg-primary text-white px-4 py-2 rounded">
-        Login
-      </button>
+      <div className="space-y-2">
+        <button type="submit" className="bg-primary text-white px-4 py-2 rounded w-full">
+          {mode === 'login' ? 'Login' : 'Register'}
+        </button>
+        <button
+          type="button"
+          onClick={() => setMode(mode === 'login' ? 'register' : 'login')}
+          className="text-sm underline w-full"
+        >
+          {mode === 'login' ? 'Need an account? Register' : 'Have an account? Login'}
+        </button>
+      </div>
     </form>
   );
 }

--- a/frontend/src/components/__tests__/AuthForm.test.jsx
+++ b/frontend/src/components/__tests__/AuthForm.test.jsx
@@ -1,17 +1,34 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import { vi, it, expect } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { vi, it, expect, afterEach } from 'vitest';
 import AuthForm from '../AuthForm';
 import * as api from '../../api';
 
 vi.mock('../../api');
 
-it('submits credentials', async () => {
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+it('logs in with credentials', async () => {
   api.login.mockResolvedValue({ access_token: 'token' });
   const onSuccess = vi.fn();
   render(<AuthForm onSuccess={onSuccess} />);
   fireEvent.change(screen.getByPlaceholderText(/email/i), { target: { value: 'a@b.com' } });
   fireEvent.change(screen.getByPlaceholderText(/password/i), { target: { value: 'secret' } });
-  fireEvent.click(screen.getByText(/login/i));
+  fireEvent.click(screen.getByRole('button', { name: /login/i }));
   await vi.waitFor(() => expect(api.login).toHaveBeenCalledWith('a@b.com', 'secret'));
+  await vi.waitFor(() => expect(onSuccess).toHaveBeenCalled());
+});
+
+it('registers a new user', async () => {
+  api.register.mockResolvedValue({ id: '1' });
+  const onSuccess = vi.fn();
+  render(<AuthForm onSuccess={onSuccess} />);
+  fireEvent.click(screen.getByRole('button', { name: /need an account/i }));
+  fireEvent.change(screen.getByPlaceholderText(/email/i), { target: { value: 'a@b.com' } });
+  fireEvent.change(screen.getByPlaceholderText(/password/i), { target: { value: 'secret' } });
+  fireEvent.click(screen.getByRole('button', { name: /register/i }));
+  await vi.waitFor(() => expect(api.register).toHaveBeenCalledWith('a@b.com', 'secret'));
   await vi.waitFor(() => expect(onSuccess).toHaveBeenCalled());
 });


### PR DESCRIPTION
## Summary
- enable login or register from a single AuthForm component with a toggle
- expand AuthForm tests to cover login and registration flows
- update README progress for authentication forms

## Testing
- `npm test -- --run` (frontend)
- `npx jest src/posts/posts.service.spec.ts --runInBand`
- `npx jest src/users/users.service.spec.ts --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_6896a879d6c4832e89d87f5ae83d33b8