### PR TITLE
Fix comment query validation and stabilize e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A prototype social platform where users can register, share posts with optional 
 - [x] Post system (create, fetch, delete, media upload) – 100%
 - [x] Likes & Comments – 100%
 - [x] Input validation & error handling – 100%
-- [ ] Test coverage (Jest/unit/integration) – ~40%
+- [ ] Test coverage (Jest/unit/integration) – ~50%
 
 ### 🎨 Frontend
 - [ ] Authentication forms & routing – ~75% (login & register implemented)

--- a/backend/src/posts/posts.controller.ts
+++ b/backend/src/posts/posts.controller.ts
@@ -11,7 +11,6 @@ import {
   UseInterceptors,
   Query,
   HttpCode,
-  UsePipes,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { PostsService } from './posts.service';
@@ -89,18 +88,17 @@ export class PostsController {
   }
 
   @Get(':id/comments')
-  @UsePipes(
-    new ZodValidationPipe(
-      z.object({
-        page: z.coerce.number().min(1).default(1).optional(),
-        limit: z.coerce.number().min(1).max(50).default(10).optional(),
-        sort: z.enum(['latest', 'oldest']).default('latest').optional(),
-      }),
-    ),
-  )
   getComments(
     @Param('id', new ZodValidationPipe(z.string().length(24))) id: string,
-    @Query()
+    @Query(
+      new ZodValidationPipe(
+        z.object({
+          page: z.coerce.number().min(1).default(1).optional(),
+          limit: z.coerce.number().min(1).max(50).default(10).optional(),
+          sort: z.enum(['latest', 'oldest']).default('latest').optional(),
+        }),
+      ),
+    )
     query: {
       page?: number;
       limit?: number;


### PR DESCRIPTION
## Summary
- validate comment listing queries with parameter-level Zod schema
- run e2e tests against MongoMemoryServer
- update README test coverage status

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896b6d50eec832eb77ab1babf401f50