### PR TITLE
feat: add basic like feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A prototype social platform where users can register, share posts with optional 
 | Area | Progress |
 |------|----------|
 | Backend | ~85% |
-| Frontend | ~50% |
+| Frontend | ~55% |
 | DevOps & Tooling | ~90% |
 | Documentation | ~75% |
 
@@ -24,7 +24,7 @@ A prototype social platform where users can register, share posts with optional 
 ### 🎨 Frontend
 - [ ] Authentication forms & routing – ~75% (login & register implemented)
 - [ ] Post feed & UI integration – ~70%
-- [ ] Like/comment functionality – ~40%
+- [ ] Like/comment functionality – ~60% (basic like/unlike working)
 - [ ] File uploads & previews – ~40%
 - [ ] Responsive layout & polish – ~60%
 - [ ] Test coverage (Vitest/unit/ui) – ~35%
@@ -36,7 +36,7 @@ A prototype social platform where users can register, share posts with optional 
 - [x] CI/CD pipelines (GitHub Actions) – 100%
 
 ### 📄 Documentation
-- [ ] README accuracy – ~85%
+- [ ] README accuracy – ~90%
 - [ ] API reference in README – ~90%
 - [ ] INSTALLATION.md completeness – ~65%
 - [x] .env.example coverage – 100%
@@ -55,6 +55,7 @@ A prototype social platform where users can register, share posts with optional 
 - React UI built with Vite and Tailwind CSS
 - Components for navigation, posts, comments, modals and upload previews
 - Connects to the API for authentication and post feeds
+- Like/unlike posts from the feed
 
 ## Technologies
 - **Backend:** Node.js, NestJS, TypeScript, Passport, JWT

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A prototype social platform where users can register, share posts with optional 
 | Area | Progress |
 |------|----------|
 | Backend | ~85% |
-| Frontend | ~55% |
+| Frontend | ~60% |
 | DevOps & Tooling | ~90% |
 | Documentation | ~75% |
 
@@ -24,7 +24,7 @@ A prototype social platform where users can register, share posts with optional 
 ### 🎨 Frontend
 - [ ] Authentication forms & routing – ~75% (login & register implemented)
 - [ ] Post feed & UI integration – ~70%
-- [ ] Like/comment functionality – ~60% (basic like/unlike working)
+- [ ] Like/comment functionality – ~80% (like/unlike and add comments)
 - [ ] File uploads & previews – ~40%
 - [ ] Responsive layout & polish – ~60%
 - [ ] Test coverage (Vitest/unit/ui) – ~35%
@@ -56,6 +56,7 @@ A prototype social platform where users can register, share posts with optional 
 - Components for navigation, posts, comments, modals and upload previews
 - Connects to the API for authentication and post feeds
 - Like/unlike posts from the feed
+- Comment on posts from the feed
 
 ## Technologies
 - **Backend:** Node.js, NestJS, TypeScript, Passport, JWT

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,26 +2,79 @@ import { useEffect, useState } from 'react';
 import Navbar from './components/Navbar';
 import PostCard from './components/PostCard';
 import AuthForm from './components/AuthForm';
-import { getPosts } from './api';
+import { getPosts, likePost, unlikePost } from './api';
+
 function App() {
   const [posts, setPosts] = useState([]);
+  const [auth, setAuth] = useState({ token: null, userId: null });
+
+  const fetchPosts = () => {
+    getPosts()
+      .then((data) => {
+        setPosts(
+          data.map((p) => ({
+            id: p.id,
+            authorId: p.authorId,
+            text: p.text,
+            mediaUrl: p.mediaUrl,
+            createdAt: p.createdAt,
+            likesCount: p.likes.length,
+            liked: auth.userId ? p.likes.includes(auth.userId) : false,
+          })),
+        );
+      })
+      .catch(console.error);
+  };
 
   useEffect(() => {
-    getPosts().then(setPosts).catch(console.error);
-  }, []);
+    fetchPosts();
+  }, [auth.userId]);
+
+  const handleAuthSuccess = (res) => {
+    const payload = JSON.parse(atob(res.access_token.split('.')[1]));
+    setAuth({ token: res.access_token, userId: payload.sub });
+  };
+
+  const handleToggleLike = async (id, liked) => {
+    if (!auth.token) return;
+    try {
+      if (liked) {
+        await unlikePost(id, auth.token);
+      } else {
+        await likePost(id, auth.token);
+      }
+      setPosts((prev) =>
+        prev.map((p) =>
+          p.id === id
+            ? {
+                ...p,
+                liked: !liked,
+                likesCount: p.likesCount + (liked ? -1 : 1),
+              }
+            : p,
+        ),
+      );
+    } catch (err) {
+      console.error(err);
+    }
+  };
 
   return (
     <div className="min-h-screen bg-background">
       <Navbar />
       <main className="mx-auto max-w-2xl space-y-4 p-4">
-        <AuthForm />
+        <AuthForm onSuccess={handleAuthSuccess} />
         {posts.map((p) => (
           <PostCard
             key={p.id}
+            id={p.id}
             author={p.authorId}
             content={p.text}
             media={p.mediaUrl}
             timestamp={p.createdAt}
+            likesCount={p.likesCount}
+            liked={p.liked}
+            onToggleLike={handleToggleLike}
           />
         ))}
       </main>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,6 +20,7 @@ function App() {
             createdAt: p.createdAt,
             likesCount: p.likes.length,
             liked: auth.userId ? p.likes.includes(auth.userId) : false,
+            commentsCount: p.comments.length,
           })),
         );
       })
@@ -74,7 +75,9 @@ function App() {
             timestamp={p.createdAt}
             likesCount={p.likesCount}
             liked={p.liked}
+            commentsCount={p.commentsCount}
             onToggleLike={handleToggleLike}
+            authToken={auth.token}
           />
         ))}
       </main>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -25,3 +25,21 @@ export async function getPosts() {
   if (!res.ok) throw new Error('Failed to fetch posts');
   return res.json();
 }
+
+export async function likePost(id, token) {
+  const res = await fetch(`${API_URL}/posts/${id}/like`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error('Failed to like post');
+  return res.json();
+}
+
+export async function unlikePost(id, token) {
+  const res = await fetch(`${API_URL}/posts/${id}/like`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error('Failed to unlike post');
+  return res.json();
+}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -43,3 +43,22 @@ export async function unlikePost(id, token) {
   if (!res.ok) throw new Error('Failed to unlike post');
   return res.json();
 }
+
+export async function getComments(id) {
+  const res = await fetch(`${API_URL}/posts/${id}/comments`);
+  if (!res.ok) throw new Error('Failed to fetch comments');
+  return res.json();
+}
+
+export async function addComment(id, content, token) {
+  const res = await fetch(`${API_URL}/posts/${id}/comments`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ content }),
+  });
+  if (!res.ok) throw new Error('Failed to add comment');
+  return res.json();
+}

--- a/frontend/src/api.test.js
+++ b/frontend/src/api.test.js
@@ -1,5 +1,5 @@
 import { vi, beforeEach, it, expect } from 'vitest';
-import { getPosts, likePost, unlikePost } from './api';
+import { getPosts, likePost, unlikePost, getComments, addComment } from './api';
 
 beforeEach(() => {
   global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve([]) });
@@ -23,5 +23,27 @@ it('unlikes a post', async () => {
   expect(fetch).toHaveBeenCalledWith(
     `${import.meta.env.VITE_API_URL}/posts/1/like`,
     { method: 'DELETE', headers: { Authorization: 'Bearer token' } },
+  );
+});
+
+it('fetches comments', async () => {
+  await getComments('1');
+  expect(fetch).toHaveBeenCalledWith(
+    `${import.meta.env.VITE_API_URL}/posts/1/comments`,
+  );
+});
+
+it('adds a comment', async () => {
+  await addComment('1', 'hi', 'token');
+  expect(fetch).toHaveBeenCalledWith(
+    `${import.meta.env.VITE_API_URL}/posts/1/comments`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer token',
+      },
+      body: JSON.stringify({ content: 'hi' }),
+    },
   );
 });

--- a/frontend/src/api.test.js
+++ b/frontend/src/api.test.js
@@ -1,5 +1,5 @@
 import { vi, beforeEach, it, expect } from 'vitest';
-import { getPosts } from './api';
+import { getPosts, likePost, unlikePost } from './api';
 
 beforeEach(() => {
   global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve([]) });
@@ -8,4 +8,20 @@ beforeEach(() => {
 it('calls posts endpoint', async () => {
   await getPosts();
   expect(fetch).toHaveBeenCalledWith(`${import.meta.env.VITE_API_URL}/posts`);
+});
+
+it('likes a post', async () => {
+  await likePost('1', 'token');
+  expect(fetch).toHaveBeenCalledWith(
+    `${import.meta.env.VITE_API_URL}/posts/1/like`,
+    { method: 'POST', headers: { Authorization: 'Bearer token' } },
+  );
+});
+
+it('unlikes a post', async () => {
+  await unlikePost('1', 'token');
+  expect(fetch).toHaveBeenCalledWith(
+    `${import.meta.env.VITE_API_URL}/posts/1/like`,
+    { method: 'DELETE', headers: { Authorization: 'Bearer token' } },
+  );
 });

--- a/frontend/src/components/PostCard.jsx
+++ b/frontend/src/components/PostCard.jsx
@@ -1,5 +1,8 @@
+import { useState } from 'react';
 import UserAvatar from './UserAvatar';
 import Button from './Button';
+import CommentBox from './CommentBox';
+import { getComments, addComment } from '../api';
 
 export default function PostCard({
   id,
@@ -10,8 +13,37 @@ export default function PostCard({
   media,
   likesCount = 0,
   liked = false,
+  commentsCount = 0,
   onToggleLike,
+  authToken,
 }) {
+  const [showComments, setShowComments] = useState(false);
+  const [comments, setComments] = useState([]);
+  const [count, setCount] = useState(commentsCount);
+
+  const toggleComments = () => {
+    setShowComments((prev) => {
+      const next = !prev;
+      if (next && comments.length === 0) {
+        getComments(id)
+          .then((res) => setComments(res.comments))
+          .catch(console.error);
+      }
+      return next;
+    });
+  };
+
+  const handleAddComment = async (text) => {
+    if (!authToken) return;
+    try {
+      const comment = await addComment(id, text, authToken);
+      setComments((prev) => [...prev, comment]);
+      setCount((c) => c + 1);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
     <article className="bg-white shadow-card rounded-md p-4 space-y-4">
       <header className="flex items-center space-x-3">
@@ -29,8 +61,24 @@ export default function PostCard({
         <Button variant="ghost" onClick={() => onToggleLike?.(id, liked)}>
           {liked ? 'Unlike' : 'Like'} ({likesCount})
         </Button>
-        <Button variant="ghost">Comment</Button>
+        <Button variant="ghost" onClick={toggleComments}>
+          Comment ({count})
+        </Button>
       </footer>
+      {showComments && (
+        <div className="space-y-4">
+          {comments.map((c) => (
+            <div key={c.id} className="flex items-start space-x-2">
+              <UserAvatar name={c.authorId} size={32} />
+              <p className="text-sm">
+                <span className="font-semibold mr-1">{c.authorId}</span>
+                {c.content}
+              </p>
+            </div>
+          ))}
+          <CommentBox onSubmit={handleAddComment} />
+        </div>
+      )}
     </article>
   );
 }

--- a/frontend/src/components/PostCard.jsx
+++ b/frontend/src/components/PostCard.jsx
@@ -1,7 +1,17 @@
 import UserAvatar from './UserAvatar';
 import Button from './Button';
 
-export default function PostCard({ author, avatar, timestamp, content, media }) {
+export default function PostCard({
+  id,
+  author,
+  avatar,
+  timestamp,
+  content,
+  media,
+  likesCount = 0,
+  liked = false,
+  onToggleLike,
+}) {
   return (
     <article className="bg-white shadow-card rounded-md p-4 space-y-4">
       <header className="flex items-center space-x-3">
@@ -16,7 +26,9 @@ export default function PostCard({ author, avatar, timestamp, content, media }) 
         {media && <img src={media} alt="" className="max-h-60 w-full object-cover rounded-md" />}
       </div>
       <footer className="flex space-x-4">
-        <Button variant="ghost">Like</Button>
+        <Button variant="ghost" onClick={() => onToggleLike?.(id, liked)}>
+          {liked ? 'Unlike' : 'Like'} ({likesCount})
+        </Button>
         <Button variant="ghost">Comment</Button>
       </footer>
     </article>

--- a/frontend/src/components/__tests__/PostCard.test.jsx
+++ b/frontend/src/components/__tests__/PostCard.test.jsx
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom/vitest';
 import PostCard from '../PostCard';
 
 it('renders post content', () => {
-  render(<PostCard author="me" content="hello" timestamp="now" />);
+  render(<PostCard id="1" author="me" content="hello" timestamp="now" />);
   expect(screen.getByText('hello')).toBeInTheDocument();
   expect(screen.getByText('me')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add API helpers and UI state to like/unlike posts
- track auth token to manage like state
- update README progress and tests

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896c5ca6b70832eb21f9a336740d85c