### PR TITLE
Align README and codebase with documented behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project: [backend, frontend]
+    defaults:
+      run:
+        working-directory: ${{ matrix.project }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: ${{ matrix.project }}/package-lock.json
+      - run: npm ci
+      - run: npm test
+      - run: npm run build --if-present
+      - if: matrix.project == 'backend'
+        run: npx tsc --noEmit

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ backend/node_modules/
 frontend/node_modules/
 .env
 backend/.env
-uploads/
-backend/uploads/
+/uploads/
+backend/uploads/*
+!backend/uploads/.gitkeep
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,0 +1,17 @@
+# Installation
+
+## Backend
+1. `cd backend`
+2. `npm install`
+3. Copy `.env.example` to `.env` and adjust values:
+   - `PORT`
+   - `JWT_SECRET`
+   - `MONGO_URI`
+   - `USE_MONGO` (optional, defaults to `false`)
+4. `npm start`
+
+## Frontend
+1. `cd frontend`
+2. `npm install`
+3. (Optional) copy `.env.example` to `.env` and set `VITE_API_URL`
+4. `npm run dev`

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A prototype social platform where users can register, share posts with optional 
    PORT=3000
    JWT_SECRET=your-secret
    MONGO_URI=mongodb://localhost:27017/bojex
+   USE_MONGO=false
    ```
 4. `npm start`
 
@@ -44,9 +45,15 @@ The server listens on `http://localhost:3000` by default. Uploaded files are sto
 ### Frontend Setup
 1. `cd frontend`
 2. `npm install`
-3. `npm run dev`
+3. (Optional) create a `.env` file with:
 
-The Vite dev server starts on `http://localhost:5173`. No environment variables are required for the frontend.
+   ```env
+   VITE_API_URL=http://localhost:3000
+   ```
+
+4. `npm run dev`
+
+The Vite dev server starts on `http://localhost:5173`. The demo UI runs locally and only attempts API calls if `VITE_API_URL` is set.
 
 ## Folder Structure
 ```
@@ -122,24 +129,25 @@ curl -X POST http://localhost:3000/users/<USER_ID>/follow \
 ### Auth
 - `POST /auth/register` – create account. Body: `{ email, password }`. Returns user without password.
 - `POST /auth/login` – authenticate and receive `{ access_token }`.
-- `POST /auth/google` – placeholder endpoint.
-- `POST /auth/discord` – placeholder endpoint.
+- `POST /auth/google` – placeholder endpoint that responds with `501 {"status":"not_implemented"}`.
+- `POST /auth/discord` – placeholder endpoint that responds with `501 {"status":"not_implemented"}`.
 
 ### Users
 - `GET /users/:id` – get public profile.
-- `POST /users/:id/follow` – toggle follow/unfollow (requires JWT).
+- `POST /users/:id/follow` – toggle follow/unfollow and return `{ following: boolean }` (requires JWT).
 
 ### Posts
 - `POST /posts` – create post with `text` and optional `media` (multipart). Requires JWT.
 - `GET /posts` – list all posts.
 - `GET /posts/:id` – view a post.
-- `POST /posts/:id/like` – like/unlike a post (requires JWT).
+- `POST /posts/:id/like` – like/unlike a post and return `{ liked, likes }` (requires JWT).
 - `POST /posts/:id/comments` – add a comment with `{ content }` (requires JWT).
 
 ## Environment Variables
 - `PORT` – server port, default `3000`.
 - `JWT_SECRET` – secret used to sign JWTs.
 - `MONGO_URI` – MongoDB connection string (unused in the prototype).
+- `USE_MONGO` – set to `true` to enable future MongoDB integration; defaults to `false`.
 
 ## Deployment Notes
 - Build the frontend with `cd frontend && npm run build` (output in `frontend/dist`).

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,4 @@
 PORT=3000
-MONGO_URI=mongodb://localhost:27017/bojex
 JWT_SECRET=your-secret-key
+MONGO_URI=mongodb://localhost:27017/bojex
+USE_MONGO=false

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Post, UseGuards, Req } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Post,
+  UseGuards,
+  Req,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
@@ -21,11 +29,17 @@ export class AuthController {
 
   @Post('google')
   googlePlaceholder() {
-    return { message: 'Google OAuth not implemented yet' };
+    throw new HttpException(
+      { status: 'not_implemented' },
+      HttpStatus.NOT_IMPLEMENTED,
+    );
   }
 
   @Post('discord')
   discordPlaceholder() {
-    return { message: 'Discord OAuth not implemented yet' };
+    throw new HttpException(
+      { status: 'not_implemented' },
+      HttpStatus.NOT_IMPLEMENTED,
+    );
   }
 }

--- a/backend/src/config/configuration.ts
+++ b/backend/src/config/configuration.ts
@@ -2,4 +2,5 @@ export default () => ({
   port: parseInt(process.env.PORT ?? '3000', 10),
   jwtSecret: process.env.JWT_SECRET ?? 'secret',
   mongoUri: process.env.MONGO_URI ?? 'mongodb://localhost:27017/bojex',
+  useMongo: process.env.USE_MONGO === 'true',
 });

--- a/backend/src/posts/posts.module.ts
+++ b/backend/src/posts/posts.module.ts
@@ -1,10 +1,7 @@
 import { Module } from '@nestjs/common';
 import { PostsService } from './posts.service';
 import { PostsController } from './posts.controller';
-import { UploadsModule } from '../uploads/uploads.module';
-
 @Module({
-  imports: [UploadsModule],
   providers: [PostsService],
   controllers: [PostsController],
 })

--- a/backend/src/posts/posts.service.ts
+++ b/backend/src/posts/posts.service.ts
@@ -32,12 +32,15 @@ export class PostsService {
 
   toggleLike(id: string, userId: string) {
     const post = this.findOne(id);
+    let liked: boolean;
     if (post.likes.has(userId)) {
       post.likes.delete(userId);
+      liked = false;
     } else {
       post.likes.add(userId);
+      liked = true;
     }
-    return { likes: post.likes.size };
+    return { liked, likes: post.likes.size };
   }
 
   addComment(id: string, authorId: string, content: string) {

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -27,13 +27,16 @@ export class UsersService {
   follow(userId: string, targetId: string) {
     const user = this.findById(userId);
     const target = this.findById(targetId);
+    let following: boolean;
     if (user.following.includes(targetId)) {
       user.following = user.following.filter((id) => id !== targetId);
       target.followers = target.followers.filter((id) => id !== userId);
+      following = false;
     } else {
       user.following.push(targetId);
       target.followers.push(userId);
+      following = true;
     }
-    return { following: user.following.length, followers: target.followers.length };
+    return { following };
   }
 }

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=


### PR DESCRIPTION
## Summary
- return 501 JSON payloads for `/auth/google` and `/auth/discord`
- fix follow/like toggles and expose optional Mongo configuration
- document env usage and add CI workflow for backend and frontend

## Testing
- `cd backend && npm test`
- `cd backend && npx tsc --noEmit`
- `cd frontend && npm test`
- `cd frontend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6896d09704fc832e829c4a524afb7cbe